### PR TITLE
Fix the issue that cannot install k3d with ks

### DIFF
--- a/kubectl-plugin/install/k3d.go
+++ b/kubectl-plugin/install/k3d.go
@@ -13,7 +13,9 @@ func newInstallK3DCmd() (cmd *cobra.Command) {
 		Short: "Install KubeSphere with k3d",
 		Long: `Install KubeSphere with k3d
 You can get more details from https://github.com/rancher/k3d/`,
-		RunE: opt.runE,
+		PreRunE:  opt.preRunE,
+		RunE:     opt.runE,
+		PostRunE: opt.postRunE,
 	}
 
 	flags := cmd.Flags()


### PR DESCRIPTION
Below is the test output:
```
[root@i-jbmafdv6 ~]# /var/data/goland/GolandProjects/ks/bin/ks install k3d
INFO[0000] Prep: Network
INFO[0000] Created network 'k3d-k3s-default'
INFO[0000] Created volume 'k3d-k3s-default-images'
INFO[0001] Creating node 'k3d-k3s-default-server-0'
INFO[0001] Creating node 'k3d-k3s-default-agent-0'
INFO[0001] Creating LoadBalancer 'k3d-k3s-default-serverlb'
INFO[0001] Starting cluster 'k3s-default'
INFO[0001] Starting servers...
INFO[0001] Starting Node 'k3d-k3s-default-server-0'
INFO[0007] Starting agents...
INFO[0007] Starting Node 'k3d-k3s-default-agent-0'
INFO[0020] Starting helpers...
INFO[0020] Starting Node 'k3d-k3s-default-serverlb'
INFO[0020] (Optional) Trying to get IP of the docker host and inject it into the cluster as 'host.k3d.internal' for easy access
INFO[0025] Successfully added host record to /etc/hosts in 3/3 nodes and to the CoreDNS ConfigMap
INFO[0025] Cluster 'k3s-default' created successfully!
INFO[0025] --kubeconfig-update-default=false --> sets --kubeconfig-switch-context=false
INFO[0025] You can now use it like this:
kubectl config use-context k3d-k3s-default
kubectl cluster-info
Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
customresourcedefinition.apiextensions.k8s.io/clusterconfigurations.installer.kubesphere.io created
namespace/kubesphere-system created
serviceaccount/ks-installer created
clusterrole.rbac.authorization.k8s.io/ks-installer created
clusterrolebinding.rbac.authorization.k8s.io/ks-installer created
deployment.apps/ks-installer created
clusterconfiguration.installer.kubesphere.io/ks-installer created
[root@i-jbmafdv6 ~]# ks get ns
NAME                STATUS   AGE
default             Active   98s
kube-system         Active   98s
kube-public         Active   98s
kube-node-lease     Active   98s
kubesphere-system   Active   78s
```